### PR TITLE
Add tested device

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Reported working:
  * Samsung Galaxy S2
  * Samsung Galaxy Spica (doesn't work with the built-in 2.1 music app)
  * Sony Ericsson Xperia X10 Mini Pro
+ * Sony Ericsson Xperia Pro
 
 Issues:
 


### PR DESCRIPTION
Scrobbler working on Xperia Pro (mk16i/mk16a) with built-in player and any other players too. Tested on both 2.3.4 and 4.0.4 stock ROM.
