### PR TITLE
StatusActivity now inflates the menu for StatusInfoNetApp due to changes...

### DIFF
--- a/src/com/adam/aslfms/StatusActivity.java
+++ b/src/com/adam/aslfms/StatusActivity.java
@@ -20,15 +20,29 @@
 package com.adam.aslfms;
 
 import android.app.TabActivity;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.widget.TabHost;
 
 import com.adam.aslfms.service.NetApp;
 import com.adam.aslfms.util.AppSettings;
+import com.adam.aslfms.util.ScrobblesDatabase;
+import com.adam.aslfms.util.Util;
 
 public class StatusActivity extends TabActivity {
 	private TabHost mTabHost;
+
+	private static final int MENU_SCROBBLE_NOW_ID = 0;
+	private static final int MENU_VIEW_CACHE_ID = 1;
+	private static final int MENU_RESET_STATS_ID = 2;
+
+	private ScrobblesDatabase mDb;
+	private AppSettings settings;
+
+	int currTab;
 
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -39,21 +53,69 @@ public class StatusActivity extends TabActivity {
 		for (NetApp napp : NetApp.values()) {
 			Intent i = new Intent(this, StatusInfoNetApp.class);
 			i.putExtra("netapp", napp.getIntentExtraValue());
-			mTabHost.addTab(mTabHost.newTabSpec(napp.toString()).setIndicator(
-				napp.getName()).setContent(i));
+			mTabHost.addTab(mTabHost.newTabSpec(napp.toString())
+					.setIndicator(napp.getName()).setContent(i));
 		}
 
 		// switch to the first netapp that is authenticated
 		AppSettings settings = new AppSettings(this);
-		int curr = 0;
+		currTab = 0;
 		NetApp[] napps = NetApp.values();
 		for (int i = 0; i < napps.length; i++) {
 			if (settings.isAuthenticated(napps[i])) {
-				curr = i;
+				currTab = i;
 				break;
 			}
 		}
 
-		mTabHost.setCurrentTab(curr);
+		mTabHost.setCurrentTab(currTab);
+
+		mDb = new ScrobblesDatabase(this);
+		mDb.open();
+		settings = new AppSettings(this);
+	}
+
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu) {
+
+		menu.add(0, MENU_SCROBBLE_NOW_ID, 0, R.string.scrobble_now).setIcon(
+				android.R.drawable.ic_menu_upload);
+		menu.add(0, MENU_RESET_STATS_ID, 0, R.string.reset_stats).setIcon(
+				android.R.drawable.ic_menu_close_clear_cancel);
+		menu.add(0, MENU_VIEW_CACHE_ID, 0, R.string.view_sc).setIcon(
+				android.R.drawable.ic_menu_view);
+
+		return super.onCreateOptionsMenu(menu);
+	}
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		final StatusInfoNetApp currentActivity = (StatusInfoNetApp) getLocalActivityManager()
+				.getCurrentActivity();
+		final NetApp mNetApp = currentActivity.getNetApp();
+		switch (item.getItemId()) {
+		case MENU_SCROBBLE_NOW_ID:
+			int numInCache = mDb.queryNumberOfScrobbles(mNetApp);
+			Util.scrobbleIfPossible(this, mNetApp, numInCache);
+			return true;
+		case MENU_VIEW_CACHE_ID:
+			Intent j = new Intent(this, ViewScrobbleCacheActivity.class);
+			j.putExtra("netapp", mNetApp.getIntentExtraValue());
+			startActivity(j);
+			return true;
+		case MENU_RESET_STATS_ID:
+			Util.confirmDialog(this, getString(R.string.confirm_stats_reset)
+					.replaceAll("%1", mNetApp.getName()), R.string.reset,
+					R.string.cancel,
+					new android.content.DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int which) {
+							settings.clearSubmissionStats(mNetApp);
+							currentActivity.fillData();
+						}
+					});
+			return true;
+		}
+		return super.onOptionsItemSelected(item);
 	}
 }

--- a/src/com/adam/aslfms/StatusInfoNetApp.java
+++ b/src/com/adam/aslfms/StatusInfoNetApp.java
@@ -52,10 +52,6 @@ public class StatusInfoNetApp extends ListActivity {
 
 	private static final String TAG = "StatusInfoNetApp";
 
-	private static final int MENU_SCROBBLE_NOW_ID = 0;
-	private static final int MENU_VIEW_CACHE_ID = 1;
-	private static final int MENU_RESET_STATS_ID = 2;
-
 	private NetApp mNetApp;
 
 	private AppSettings settings;
@@ -110,7 +106,7 @@ public class StatusInfoNetApp extends ListActivity {
 		fillData();
 	}
 
-	private void fillData() {
+	protected void fillData() {
 		List<Pair> list = new ArrayList<Pair>();
 		int numInCache = mDb.queryNumberOfScrobbles(mNetApp);
 
@@ -174,48 +170,6 @@ public class StatusInfoNetApp extends ListActivity {
 				R.layout.status_info_row, R.id.key, list);
 
 		setListAdapter(adapter);
-	}
-
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		boolean ret = super.onCreateOptionsMenu(menu);
-
-		menu.add(0, MENU_SCROBBLE_NOW_ID, 0, R.string.scrobble_now).setIcon(
-				android.R.drawable.ic_menu_upload);
-		menu.add(0, MENU_RESET_STATS_ID, 0, R.string.reset_stats).setIcon(
-				android.R.drawable.ic_menu_close_clear_cancel);
-		menu.add(0, MENU_VIEW_CACHE_ID, 0, R.string.view_sc).setIcon(
-				android.R.drawable.ic_menu_view);
-
-		return ret;
-	}
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		switch (item.getItemId()) {
-		case MENU_SCROBBLE_NOW_ID:
-			int numInCache = mDb.queryNumberOfScrobbles(mNetApp);
-			Util.scrobbleIfPossible(this, mNetApp, numInCache);
-			return true;
-		case MENU_VIEW_CACHE_ID:
-			Intent j = new Intent(this, ViewScrobbleCacheActivity.class);
-			j.putExtra("netapp", mNetApp.getIntentExtraValue());
-			startActivity(j);
-			return true;
-		case MENU_RESET_STATS_ID:
-			Util.confirmDialog(this, getString(R.string.confirm_stats_reset)
-					.replaceAll("%1", mNetApp.getName()), R.string.reset,
-					R.string.cancel,
-					new android.content.DialogInterface.OnClickListener() {
-						@Override
-						public void onClick(DialogInterface dialog, int which) {
-							settings.clearSubmissionStats(mNetApp);
-							fillData();
-						}
-					});
-			return true;
-		}
-		return super.onOptionsItemSelected(item);
 	}
 
 	@Override
@@ -284,6 +238,10 @@ public class StatusInfoNetApp extends ListActivity {
 			}
 		}
 	};
+	
+	protected synchronized NetApp getNetApp() {
+		return mNetApp;
+	}
 
 	private static class Pair {
 		private String key;


### PR DESCRIPTION
... in how TabActivity works in 3.0 and above.

I moved the onOptionsItemSelected and onCreateOptionsMenu from StatusInfoNetApp to StatusActivity so the TabActivity can directly inflate the menu. In onOptionsItemSelected, I retrieve the current instance of StatusInfoNetApp with getCurrentActivity(), and the rest is handled by the current code form there.
