### PR TITLE
Resolved Null Pointer Exception when trying to reset stats

### DIFF
--- a/src/com/adam/aslfms/StatusActivity.java
+++ b/src/com/adam/aslfms/StatusActivity.java
@@ -72,7 +72,6 @@ public class StatusActivity extends TabActivity {
 
 		mDb = new ScrobblesDatabase(this);
 		mDb.open();
-		settings = new AppSettings(this);
 	}
 
 	@Override
@@ -110,6 +109,7 @@ public class StatusActivity extends TabActivity {
 					new android.content.DialogInterface.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
+							settings = new AppSettings(StatusActivity.this);
 							settings.clearSubmissionStats(mNetApp);
 							currentActivity.fillData();
 						}


### PR DESCRIPTION
Although settings was being initialized in onCreate(), trying to reset your stats would result in a null pointer exception in practice. I moved the initialization to the onOptionsItemSelected() to resolve this.

Sorry about not testing this!
