### PR TITLE
Cleanup Database Connection Usage

### DIFF
--- a/src/com/adam/aslfms/receiver/MusicAPI.java
+++ b/src/com/adam/aslfms/receiver/MusicAPI.java
@@ -393,7 +393,9 @@ public class MusicAPI {
 	        			DatabaseHelper dbh = new DatabaseHelper(_context.getApplicationContext());
 			        	db = dbh.getWritableDatabase();
 			        	if(db.isOpen()==false){
-			        		Log.e("M2D2","Could not open M2D2 database");
+			        		Log.e(TAG,"Could not open MusicAPI database");
+			        		db = null;
+			        		return null;
 			        	}
 		        	}
 	        		++count;

--- a/src/com/adam/aslfms/util/ScrobblesDatabase.java
+++ b/src/com/adam/aslfms/util/ScrobblesDatabase.java
@@ -85,7 +85,9 @@ public class ScrobblesDatabase {
 	        			DatabaseHelper dbh = new DatabaseHelper(_context.getApplicationContext());
 			        	db = dbh.getWritableDatabase();
 			        	if(db.isOpen()==false){
-			        		Log.e("M2D2","Could not open M2D2 database");
+			        		Log.e(TAG,"Could not open ScrobblesDatabase");
+			        		db = null;
+			        		return null;
 			        	}
 		        	}
 	        		++count;


### PR DESCRIPTION
For Issue #30
I spent awhile on this issue and in Android it certainly isn't clear what the 'correct' paradigm is.

This is the best that I have been able to come up with - which is to create an Application-wide Singleton and keep a proper count of connections so that the database can be closed properly on exit and allow resources to be released.
