### PR TITLE
Adds support for JRT Studio build of Android Music Player

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="gen"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -74,6 +74,17 @@
             </intent-filter>
         </receiver>
 
+         <receiver
+            android:name="com.adam.aslfms.receiver.AndroidMusicJRTStudioBuildReceiver"
+            android:exported="true"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="com.jrtstudio.music.metachanged" />
+                <action android:name="com.jrtstudio.music.playstatechanged" />
+                <action android:name="com.jrtstudio.music.playbackcomplete" />
+            </intent-filter>
+        </receiver>
+        
         <receiver
             android:name="com.adam.aslfms.receiver.HeroMusicReceiver"
             android:exported="true"

--- a/project.properties
+++ b/project.properties
@@ -13,5 +13,5 @@
 # Indicates whether an apk should be generated for each density.
 split.density=false
 # Project target.
-target=android-12
+target=android-15
 apk-configurations=

--- a/src/com/adam/aslfms/receiver/AndroidMusicJRTStudioBuildReceiver.java
+++ b/src/com/adam/aslfms/receiver/AndroidMusicJRTStudioBuildReceiver.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Simple Last.fm Scrobbler.
+ * 
+ *     http://code.google.com/p/a-simple-lastfm-scrobbler/
+ * 
+ * Copyright 2011 Simple Last.fm Scrobbler Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adam.aslfms.receiver;
+
+import android.content.Context;
+
+import com.adam.aslfms.util.Util;
+
+/**
+ * A BroadcastReceiver for intents sent by the Android Music Player.
+ * 
+ * @see AbstractPlayStatusReceiver
+ * 
+ * @author grodin
+ * @since 1.4.3
+ */
+public class AndroidMusicJRTStudioBuildReceiver extends BuiltInMusicAppReceiver {
+
+	public static final String ACTION_ANDROID_PLAYSTATECHANGED = "com.jrtstudio.music.playstatechanged";
+	public static final String ACTION_ANDROID_STOP = "com.jrtstudio.music.playbackcomplete";
+	public static final String ACTION_ANDROID_METACHANGED = "com.jrtstudio.music.metachanged";
+
+	public static final String PACKAGE_NAME = "com.jrtstudio.music";
+	public static final String NAME = "Android Music Player (JRT Studio Build)";
+
+	static final String GOOGLE_MUSIC_PACKAGE = "com.jrtstudio.music";
+
+	public AndroidMusicJRTStudioBuildReceiver() {
+		super(ACTION_ANDROID_STOP, PACKAGE_NAME, NAME);
+	}
+
+	boolean shouldFetchFromMediaStore(Context ctx, long audioid) {
+		if (Util.checkForInstalledApp(ctx, PACKAGE_NAME))
+			return false;
+		return super.shouldFetchFromMediaStore(ctx, audioid);
+	}
+
+}

--- a/test/.classpath
+++ b/test/.classpath
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/sls"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/test/project.properties
+++ b/test/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-8
+target=android-10


### PR DESCRIPTION
Issue #46 requests support for the JRT Studio build of Android Music Player (https://play.google.com/store/apps/details?id=com.jrtstudio.music&hl=en). This patch resolves the issue.

I guessed that the JRT Studio build just used the same intents and package info as the standard Android Music Player, except that "com.android.music" and "com.google.android.music" is changed to "com.jrtstudio.music" everywhere, and that guess seems to have been correct. I've tested it a bit and it seems to "just work", but it's possible there's some subtle bug lurking somewhere.

The only two files to pull are:
- the updated AndroidManifest.xml 
- src/com/adam/aslfms/receiver/AndroidMusicJRTStudioBuildReceiver.java
