### PR TITLE
Add android.permission.READ_EXTERNAL_STORAGE

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:icon="@drawable/icon"


### PR DESCRIPTION
On my Nexus 5 running 4.4 the app crashes whenever I change songs. The message says it is missing this permission. It works perfectly after I add it locally.
