### PR TITLE
Annoying Toast #171

### DIFF
--- a/src/com/adam/aslfms/receiver/SamsungMusicReceiver.java
+++ b/src/com/adam/aslfms/receiver/SamsungMusicReceiver.java
@@ -22,6 +22,7 @@ package com.adam.aslfms.receiver;
 import android.content.Context;
 import android.os.Bundle;
 import android.widget.Toast;
+import android.util.Log;
 
 /**
  * A BroadcastReceiver for intents sent by the Samsung default Music Player.
@@ -32,6 +33,8 @@ import android.widget.Toast;
  * @since 1.3.1
  */
 public class SamsungMusicReceiver extends BuiltInMusicAppReceiver {
+
+	static final String TAG = "SamsungMusicReceiver";
 
 	public static final String ACTION_SAMSUNG_PLAYSTATECHANGED = "com.samsung.sec.android.MusicPlayer.playstatechanged";
 	public static final String ACTION_SAMSUNG_STOP = "com.samsung.sec.android.MusicPlayer.playbackcomplete";
@@ -45,7 +48,7 @@ public class SamsungMusicReceiver extends BuiltInMusicAppReceiver {
 	@Override
 	protected void parseIntent(Context ctx, String action, Bundle bundle)
 			throws IllegalArgumentException {
-		Toast.makeText(ctx, "MP: " + action, Toast.LENGTH_LONG).show();
+		Log.e(TAG, "MP: " + action);
 		super.parseIntent(ctx, action, bundle);
 	}
 


### PR DESCRIPTION
Log.e() instead of make Toast so users aren't bombarded with popups but programmers can still debug SamsungMusicReceiver.