### PR TITLE
Fix for fatal LINT warnings

### DIFF
--- a/res/values-fr/strings_mapis.xml
+++ b/res/values-fr/strings_mapis.xml
@@ -14,7 +14,6 @@
         name="show_supported_apps_list_summary">Choix des applications depuis lesquelles il faut scrobbler</string>
     <string
         name="supported_apps_category_title">Applications activées</string>
-    <string name="scrobble_droid_supported_apps">Applications supportées par Scrobble Droid</string><!-- Unused for now. See : ScrobbleDroidMusicReceiver.java -->
     <string
         name="app_disabled">Pas de scrobble depuis cette application</string>
     <string

--- a/res/values/authentication.xml
+++ b/res/values/authentication.xml
@@ -2,6 +2,6 @@
 <resources>
 	<!-- These values should only be used in _this_ application -->
 	<!-- Use tst / 1.0 for testing purposes, or ask Last.fm for new ones for your app -->
-	<string name="client_id">sls</string>
-	<string name="client_ver">1.1</string>
+	<string name="client_id" translatable="false">sls</string>
+	<string name="client_ver" translatable="false">1.1</string>
 </resources>


### PR DESCRIPTION
For some reason when exporting from eclipse. Android LINT was complaining about some of the resources. I'm guessing due to the other locales being pulled in.

This should prevent this happening now.