### PR TITLE
Added back carets for at least v16 and up

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,3 +20,7 @@ android {
         }
     }
 }
+
+dependencies {
+    compile 'com.android.support:support-v4:22.1.1'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,10 +13,6 @@
         android:xlargeScreens="true"
         android:anyDensity="true" />
 
-    <uses-sdk
-        android:minSdkVersion="7"
-        android:targetSdkVersion="12" />
-
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
@@ -42,13 +38,61 @@
         </activity>
 
         <!-- other activities -->
-        <activity android:name="com.adam.aslfms.UserCredsListScreen" />
-        <activity android:name="com.adam.aslfms.MusicAppsScreen" />
-        <activity android:name="com.adam.aslfms.OptionsScreen" />
-        <activity android:name="com.adam.aslfms.UserCredActivity" />
-        <activity android:name="com.adam.aslfms.StatusActivity" />
-        <activity android:name="com.adam.aslfms.StatusInfoNetApp" />
-        <activity android:name="com.adam.aslfms.ViewScrobbleCacheActivity" />
+        <activity
+            android:name=".UserCredsListScreen"
+            android:parentActivityName=".SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".SettingsActivity" />
+        </activity>
+
+        <activity
+            android:name=".MusicAppsScreen"
+            android:parentActivityName=".SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".SettingsActivity" />
+        </activity>
+
+        <activity
+            android:name=".OptionsScreen"
+            android:parentActivityName=".SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".SettingsActivity" />
+        </activity>
+
+        <activity
+            android:name=".UserCredActivity"
+            android:parentActivityName=".UserCredsListScreen">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".UserCredsListScreen" />
+        </activity>
+
+        <activity
+            android:name=".StatusActivity"
+            android:parentActivityName=".SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".SettingsActivity" />
+        </activity>
+
+        <activity
+            android:name=".StatusInfoNetApp"
+            android:parentActivityName=".SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".SettingsActivity" />
+        </activity>
+
+        <activity
+            android:name=".ViewScrobbleCacheActivity"
+            android:parentActivityName=".SettingsActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".SettingsActivity" />
+        </activity>
 
         <!-- the service -->
         <service

--- a/app/src/main/java/com/adam/aslfms/MusicAppsScreen.java
+++ b/app/src/main/java/com/adam/aslfms/MusicAppsScreen.java
@@ -21,6 +21,7 @@ package com.adam.aslfms;
 
 import java.util.HashMap;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
@@ -50,6 +51,10 @@ public class MusicAppsScreen extends PreferenceActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.music_apps);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			getActionBar().setDisplayHomeAsUpEnabled(true);
+		}
 
 		mSupportedMusicAppsList = (PreferenceCategory) findPreference(KEY_SUPPORTED_MUSICAPPS_LIST);
 		mPrefsToMapisMap = new HashMap<CheckBoxPreference, MusicAPI>();

--- a/app/src/main/java/com/adam/aslfms/OptionsScreen.java
+++ b/app/src/main/java/com/adam/aslfms/OptionsScreen.java
@@ -19,6 +19,7 @@
 
 package com.adam.aslfms;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
@@ -54,6 +55,10 @@ public class OptionsScreen extends PreferenceActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.options);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			getActionBar().setDisplayHomeAsUpEnabled(true);
+		}
 
 		settings = new AppSettings(this);
 

--- a/app/src/main/java/com/adam/aslfms/StatusActivity.java
+++ b/app/src/main/java/com/adam/aslfms/StatusActivity.java
@@ -22,6 +22,7 @@ package com.adam.aslfms;
 import android.app.TabActivity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/app/src/main/java/com/adam/aslfms/StatusInfoNetApp.java
+++ b/app/src/main/java/com/adam/aslfms/StatusInfoNetApp.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;

--- a/app/src/main/java/com/adam/aslfms/UserCredActivity.java
+++ b/app/src/main/java/com/adam/aslfms/UserCredActivity.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.DialogInterface.OnClickListener;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -62,6 +63,10 @@ public class UserCredActivity extends PreferenceActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.user_cred_prefs);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			getActionBar().setDisplayHomeAsUpEnabled(true);
+		}
 
 		String snapp = getIntent().getExtras().getString("netapp");
 		if (snapp == null) {

--- a/app/src/main/java/com/adam/aslfms/UserCredsListScreen.java
+++ b/app/src/main/java/com/adam/aslfms/UserCredsListScreen.java
@@ -27,6 +27,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.DialogInterface.OnClickListener;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -55,6 +56,11 @@ public class UserCredsListScreen extends PreferenceActivity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			getActionBar().setDisplayHomeAsUpEnabled(true);
+		}
+
 		addPreferencesFromResource(R.xml.user_creds_list);
 
 		settings = new AppSettings(this);

--- a/app/src/main/java/com/adam/aslfms/ViewScrobbleCacheActivity.java
+++ b/app/src/main/java/com/adam/aslfms/ViewScrobbleCacheActivity.java
@@ -28,6 +28,7 @@ import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -69,6 +70,10 @@ public class ViewScrobbleCacheActivity extends ListActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			getActionBar().setDisplayHomeAsUpEnabled(true);
+		}
 
 		settings = new AppSettings(this);
 


### PR DESCRIPTION
Hey all,

I made a simple change that should improve the app. I added back carets to most of the app for [up navigation](http://developer.android.com/training/implementing-navigation/ancestral.html). I couldn't get it working 100% for the Status screen (I think), but I need to rewrite that entire Activity for the AppCompat work I'm doing. I believe what is currently here should work for everything except phones running 4.0 or 4.1.

I tested these changes on:
- Nexus 4 running 5.1
- Samsung Captivate running 4.2
- Emulator running 2.3.4

And here's a pic:
![screenshot_2015-06-02-23-10-29](https://cloud.githubusercontent.com/assets/1190702/7952637/66eb3366-097e-11e5-999c-3366ddd3f788.png)
