### PR TITLE
App-recognition for music players who identify as com.android.music

### DIFF
--- a/app/src/main/java/com/adam/aslfms/receiver/BuiltInMusicAppReceiver.java
+++ b/app/src/main/java/com/adam/aslfms/receiver/BuiltInMusicAppReceiver.java
@@ -22,6 +22,7 @@ package com.adam.aslfms.receiver;
 
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.provider.MediaStore;
@@ -95,8 +96,23 @@ public abstract class BuiltInMusicAppReceiver extends
 	}
 
 	MusicAPI getMusicAPI(Context ctx, Bundle bundle) {
-		CharSequence bundleAppName = bundle.getCharSequence("player");
-		CharSequence bundleAppPackage = bundle.getCharSequence("package");
+		CharSequence bundleAppName;
+		CharSequence bundleAppPackage;
+
+		bundleAppPackage = bundle.getCharSequence("scrobbling_source");
+		if (bundleAppPackage != null)
+		{
+			PackageManager packageManager = ctx.getPackageManager();
+			try {
+				bundleAppName = packageManager.getApplicationLabel(packageManager.getApplicationInfo(bundleAppPackage.toString(), PackageManager.GET_META_DATA));
+			} catch (PackageManager.NameNotFoundException e) {
+				bundleAppName = bundle.getCharSequence("player");
+				bundleAppPackage = bundle.getCharSequence("package");
+			}
+		} else {
+			bundleAppName = bundle.getCharSequence("player");
+			bundleAppPackage = bundle.getCharSequence("package");
+		}
 
 		MusicAPI musicAPI;
 		if ((bundleAppName != null) && (bundleAppPackage != null)) {


### PR DESCRIPTION
A lot of Music-Players identify themselfs as the "generic android music player" and sending broadcasts with **com.android.music.XXX** intents
Scrobbling support in this case is implemented, but no "app recognition feature"
As some of theese music apps also include an extra String **"scrobbling_source"** 
eg. `bundle.putString("scrobbling_source", "com.examplecompany.exampleapp");`
we can add App-recognition in case an app does exactly this.