### PR TITLE
Spanish translation corrections

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -85,7 +85,7 @@
     <string name="auth_just_error">Error, reintentando…</string>
     <string name="logged_in_just">Registrado como:</string>
     <string name="logged_in_as">Registrado como: %1</string>
-    <string name="log_in_to">Ingresar en</string>
+    <string name="log_in_to">Iniciar sesión en</string>
     <string name="not_logged_in">No ha iniciado sesión</string>
     <string name="create_user_title">Registrarse</string>
     <string name="create_user_summary">Registre una cuenta nueva en %1</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <!-- START original strings -->
     <string name="close">Cerrar</string>
     <string name="remove">Eliminar</string>
-    <string name="reset">Resetear</string>
+    <string name="reset">Reiniciar</string>
     <string name="clear_creds">Limpiar</string>
     <string name="are_you_sure">¿Está seguro?</string>
     <string name="warning">Atención</string>
@@ -17,16 +17,16 @@
     <string name="by">por</string>
     <string name="issues">Incidencias: %s</string>
     <string name="website">Página web: %s</string>
-    <string name="troubShoot">Solucionar Problemas: %s</string>
+    <string name="troubShoot">Solucionar problemas: %s</string>
     <string name="by_adam">por Adam Renberg</string>
     <string name="license">Liberado bajo Licencia Apache 2.0</string>
-    <string name="about_text">Un ligero cliente para hacer Scrobbling que envía información a Last.fm (y/o a Libre.fm) sobre qué música reproduces en tu móvil con Android. Last.fm te permite entonces ver estadísticas de lo escuchado y recomendarle nueva música que puede gustarle.</string>
+    <string name="about_text">Un ligero cliente de scrobbling que envía información a Last.fm (y/o a Libre.fm) sobre qué música reproduces en tu dispositivo Android. Last.fm te permite ver estadísticas de lo que has escuchado y recomendarte nueva música que pueda gustarte.</string>
     <string name="everything_disabled">Scrobbling/Escuchando ahora desactivado.</string>
     <string name="file_error">¡Error del archivo!</string>
     <string name="thats_new">Novedades</string>
     <string name="about">Acerca de</string>
     <string name="whats_new">Novedades</string>
-    <string name="supported_netapps">Páginas webs soportadas: %1</string>
+    <string name="supported_netapps">Sitios web soportados: %1</string>
     <string name="supported_apps">Aplicaciones soportadas: %s y más…</string>   
     <!-- END about strings -->
 
@@ -34,8 +34,8 @@
     <string name="scrobbles_cache_nonum">Scrobbles en la caché local:</string>
     <string name="scrobbles_cache">Scrobbles en la caché local: %1</string>
     <string name="db_error">Error de la base de datos</string>
-    <string name="scrobble_now">Enviar Scrobbles</string>
-    <string name="reset_stats">Restarurar las estadísticas</string>
+    <string name="scrobble_now">Enviar scrobbles</string>
+    <string name="reset_stats">Limpiar estadísticas</string>
     <string name="scrobble_cache_title">Caché de scrobbles</string>
     <string name="confirm_delete_sc">¿Está seguro de que no quiere scrobblear esta pista de %1? Esta operación no se puede deshacer.</string>
     <string name="confirm_delete_sc_from_all">¿Está seguro de que no quiere scrobblear esta pista? Esta operación no se puede deshacer..</string>
@@ -49,43 +49,43 @@
     <string name="track_info">Información de pista</string>
     <string name="view_sc_title_for">Caché de scrobbles de %1</string>
     <string name="view_sc_for_all_summary">Ver y editar la lista de scrobbles sin enviar</string>
-    <string name="all_websites">todas las páginas web</string>
+    <string name="all_websites">Todos los sitios web</string>
     <string name="sc_sorted_by">Ordenar por: %1</string>
     <string name="sc_sort_title">Criterio de ordenación</string>
     <string name="sc_sortorder_change">Cambiar el criterio de ordenación</string>
-    <string name="sc_sort_when_asc">Tiempo reproducido, ascendiente</string>
-    <string name="sc_sort_when_desc">Tiempo reproducido, descendiente</string>
-    <string name="sc_sort_artist_asc">Artista, ascendiente</string>
-    <string name="sc_sort_artist_desc">Artista, descendiente</string>
-    <string name="sc_sort_album_asc">Álbum, ascendiente</string>
-    <string name="sc_sort_album_desc">Álbum, descendiente</string>
-    <string name="sc_sort_track_asc">Nombre de la pista, ascendiente</string>
-    <string name="sc_sort_track_desc">Nombre de la pista, descendiente</string> 
+    <string name="sc_sort_when_asc">Tiempo reproducido, ascendente</string>
+    <string name="sc_sort_when_desc">Tiempo reproducido, descendente</string>
+    <string name="sc_sort_artist_asc">Artista, ascendente</string>
+    <string name="sc_sort_artist_desc">Artista, descendente</string>
+    <string name="sc_sort_album_asc">Álbum, ascendente</string>
+    <string name="sc_sort_album_desc">Álbum, descendente</string>
+    <string name="sc_sort_track_asc">Nombre de la pista, ascendente</string>
+    <string name="sc_sort_track_desc">Nombre de la pista, descendente</string> 
     <!-- END cache strings -->  
     
     <!-- START creds strings -->
     <string name="user_credentials_title">Credenciales de usuario</string>
     <string name="user_credentials_summary">Introduce tu nombre de usuario y contraseña de tu cuenta en %1</string>
-    <string name="user_credentials_summary_no_napp">Establece el nombre de usuario y contraseña para de cada cuenta</string>
-    <string name="user_credentials_enter_ok">Autentificar</string>
+    <string name="user_credentials_summary_no_napp">Establece el nombre de usuario y contraseña para cada cuenta</string>
+    <string name="user_credentials_enter_ok">Iniciar sesión</string>
     <string name="user_credentials_enter_cancel">Cancelar</string>
     <string name="user_credentials_clear_title">Limpiar credenciales</string>
     <string name="user_credentials_clear_summary">Limpiar nombre de usuario y contraseña</string>
     <string name="supported_netapps_category_title">Páginas soportadas</string>
     <string name="username">Nombre de usuario</string>
-    <string name="password">contraseña</string>
+    <string name="password">Contraseña</string>
     <string name="auth_client_banned">Esta versión es inválida, por favor, actualízala</string>
     <string name="auth_bad_auth">Nombre de usuario/contraseña incorrecto/a</string>
-    <string name="auth_server_error">Error del servidor: %1, reintentándolo…</string>
-    <string name="auth_timing_error">Error en el tiempo del cliente, reintentándolo…</string>
-    <string name="auth_network_error_retrying">Error de conexión, reintentándolo…</string>
-    <string name="auth_network_unfit">No se permite enviar información con conexión móvil, puedes cambiarlo en Opciones</string>
+    <string name="auth_server_error">Error del servidor: %1, reintentando…</string>
+    <string name="auth_timing_error">Error en el tiempo del cliente, reintentando…</string>
+    <string name="auth_network_error_retrying">Error de conexión, reintentando…</string>
+    <string name="auth_network_unfit">No se permite enviar información con datos móviles, puedes cambiarlo en Opciones</string>
     <string name="auth_updating">Autentificando…</string>
     <string name="auth_internal_error">Error interno</string>
-    <string name="auth_just_error">Error, reintentándolo…</string>
+    <string name="auth_just_error">Error, reintentando…</string>
     <string name="logged_in_just">Registrado como:</string>
     <string name="logged_in_as">Registrado como: %1</string>
-    <string name="log_in_to">Registrarse en</string>
+    <string name="log_in_to">Ingresar en</string>
     <string name="not_logged_in">No ha iniciado sesión</string>
     <string name="create_user_title">Registrarse</string>
     <string name="create_user_summary">Registre una cuenta nueva en %1</string>
@@ -94,76 +94,76 @@
     <!-- END creds strings -->
 
     <!-- START heart strings -->
-    <string name="heart_and_copy">Opciones de Canciones</string>
-    <string name="heart_title">Amado</string>
-    <string name="heart_current_track">Canción de amor en last.fm</string>
-    <string name="no_heart_track">Amado Canción Falló</string>
-    <string name="loved_track">Amado Canción</string>
-    <string name="no_lastFm">Por favor, introduzca sus credenciales de Last.fm (Libre.fm)</string>
-    <string name="song_is_ready">Song anu disusun</string>
+    <string name="heart_and_copy">Opciones de canciones</string>
+    <string name="heart_title">Favorito</string>
+    <string name="heart_current_track">Marcar como favorito el tema actual en Last.fm</string>
+    <string name="no_heart_track">Error marcando el tema como favorito</string>
+    <string name="loved_track">Tema marcado como favorito</string>
+    <string name="no_lastFm">Por favor, introduzca sus credenciales de Last.fm/Libre.fm</string>
+    <string name="song_is_ready">Tema listo</string>
     <!-- END heart strings -->
 
     <!-- START copy strings -->
-    <string name="copy_title">Dupdo</string>
-    <string name="copy_current_track">Copia actual de la canción al portapapeles</string>
-    <string name="no_copy_track">Copia Canción Falló</string>
-    <string name="no_current_track">No Song actual Disponible</string>
+    <string name="copy_title">Copiar</string>
+    <string name="copy_current_track">Copia tema actual al portapapeles</string>
+    <string name="no_copy_track">Error al copiar el tema</string>
+    <string name="no_current_track">No hay tema actual disponible</string>
     <!-- END copy strings -->
 
     <!-- START permissions and warnings strings -->
-    <string name="permission_required">Permission REQUIRED to work properly</string>
-    <string name="creds_required">Credentials REQUIRED to work properly</string>
-    <string name="limited_network">Red Limitada</string>
+    <string name="permission_required">Permiso REQUERIDO para funcionar correctamente</string>
+        <string name="creds_required">Credenciales REQUERIDAS para funcionar correctamente</string>
+    <string name="limited_network">Red limitada</string>
     <!-- END permissions and warnings strings -->
     
     <!-- START mapis strings -->
     <string name="incompatability_short">Atención: %1$s está instalada y puede causar doble scrobbleo.</string>
     <string name="incompatability_long">Atención: %1$s está instalada y puede producir incompatibilidades al scrobblear. Desactive el scrobbleo desde esta aplicación o desinstale %1$s.</string>
     <string name="show_supported_apps_list_summary">Activar/Desactivar scrobbleo desde una aplicación</string>
-    <string name="supported_apps_category_title">aplicaciones activas</string>
+    <string name="supported_apps_category_title">Aplicaciones activas</string>
     <string name="app_disabled">No se scrobbleará música desde esta aplicación</string>
     <string name="not_installed">Esta aplicación no está instalada</string>
     <string name="no_supported_mapis_title">No se detectan aplicaciones de música</string>
     <string name="find_supported_mapis_one_title">Una aplicación de música detectada</string>
     <string name="find_supported_mapis_many_title">%1 aplicaciones de música detectadas</string>
-    <string name="find_supported_mapis_summary">Al reproducir música en una aplicación soportada, aparecerá aquí</string>
-    <string name="unknown_mapi">aplicación desconocida (pre SLS v1.2.3)</string>
+    <string name="find_supported_mapis_summary">Cuando reproduzcas música en una aplicación soportada, esta aparecerá aquí</string>
+    <string name="unknown_mapi">Aplicación desconocida (pre SLS v1.2.3)</string>
     <!-- END mapis strings -->
     
     <!-- START options strings -->
     <string name="options_title">Opciones</string>
     <string name="advanced_options_title">Opciones avanzadas</string>
     <string name="scrobbling">Scrobbleo</string>
-    <string name="scrobbling_enable">Enviar información cuando escuche una canción</string>
+    <string name="scrobbling_enable">Enviar información luego de escuchar un tema</string>
     <string name="nowplaying">Notificar \'Escuchando ahora\'</string>
-    <string name="nowplaying_enable">Mostrar qué canción está escuchando ahora</string>
+    <string name="nowplaying_enable">Mostrar qué tema está escuchando actualmente</string>
     <string name="scrobble_point_title">Porcentaje para scrobblear</string>
-    <string name="scrobble_point_summary">Se memorizará en la caché cuando se reproduca un %1%</string>
-    <string name="ao_battery_title">Sólo batería</string>
-    <string name="ao_plugged_title">Enchufado</string>
-    <string name="options_summary">Incluyendo opciones para el ahorro de batería</string>
-    <string name="advanced_options_notify_title">Notificaciones de Teléfono</string>
+    <string name="scrobble_point_summary">Se almacenará en la caché cuando se reproduca un %1%</string>
+    <string name="ao_battery_title">Sólo con batería</string>
+    <string name="ao_plugged_title">Conectado</string>
+    <string name="options_summary">Incluye opciones para el ahorro de batería</string>
+    <string name="advanced_options_notify_title">Notificaciones de teléfono</string>
     <string name="advanced_options_custom_category_title">Opciones personalizadas para scrobblear</string>
     <string name="advanced_options_when_title">Cuándo scrobblear</string>
     <string name="advanced_options_also_on_complete_title">También al finalizar la lista de reproducción</string>
     <string name="advanced_options_also_on_complete_summary">También scrobbleará cuando haya finalizado la lista de reproducción</string>
-    <string name="advanced_options_also_on_plugged_title">También cuando esté enchufado</string>
-    <string name="advanced_options_also_on_plugged_summary">También scrobleará cuando esté enchufado a la corriente</string>
+    <string name="advanced_options_also_on_plugged_title">También cuando esté conectado</string>
+    <string name="advanced_options_also_on_plugged_summary">También scrobbleará cuando esté conectado a la corriente</string>
     <string name="should_disable_np">Debería deshabilitar \'Escuchando ahora\' para un mejor ahorro de la batería</string>
     <string name="advanced_options_type_standard_name">Estándar</string>
     <string name="advanced_options_type_battery_name">Ahorro de batería</string>
     <string name="advanced_options_type_same_as_battery_name">Igual que cuando sólo está la batería</string>
-    <string name="advanced_options_type_custom_name">Personalizadas</string>
+    <string name="advanced_options_type_custom_name">Personalizada</string>
     <string name="advanced_options_when_1_name">Después de cada pista</string>
-    <string name="advanced_options_when_5_name">Después de cinco pistas</string>
-    <string name="advanced_options_when_10_name">Después de diez pistas</string>
+    <string name="advanced_options_when_5_name">Después de 5 pistas</string>
+    <string name="advanced_options_when_10_name">Después de 10 pistas</string>
     <string name="advanced_options_when_25_name">Después de 25 pistas</string>
     <string name="advanced_options_when_never_name">Cuando pulse el botón \'Enviar Scrobbles\'</string>
     <string name="advanced_options_net_title">Conexión</string>
     <string name="advanced_options_net_summary">Enviar datos con: %1</string>
     <string name="advanced_options_net_any_name">Cualquier red</string>
-    <string name="advanced_options_net_3gup_name">3G y Wifi</string>
-    <string name="advanced_options_net_wifi_name">Sólo Wifi</string>
+    <string name="advanced_options_net_3gup_name">Datos y WiFi</string>
+    <string name="advanced_options_net_wifi_name">Sólo WiFi</string>
     <string name="advanced_options_net_roaming_title">Itinerancia de datos</string>
     <string name="advanced_options_net_roaming_summary_off">No enviará información bajo itinerancia</string>
     <string name="advanced_options_net_roaming_summary_on">Enviará información bajo itinerancia</string>    
@@ -171,10 +171,10 @@
     
     <!-- START status strings -->
     <string name="status">Estado</string>
-    <string name="scrobble_status_title">Scrobble status</string>
+    <string name="scrobble_status_title">Estado del scrobbleo</string>
     <string name="other_category_title">Otro</string>
     <string name="status_show_title">Estado</string>
-    <string name="status_show_summary">Mostrar estadísticas y estados completos</string>
+    <string name="status_show_summary">Mostrar estadísticas y estado general</string>
     <string name="status_title">Información de estado</string>
     <string name="scrobbling_disabled">Scrobbleo desactivado</string>
     <string name="scrobble_last_at">Último scrobble enviado:</string>
@@ -186,7 +186,7 @@
     <string name="never">Nunca</string>
     <string name="stats_nps">Todas las notificaciones de \'Escuchando ahora\':</string>
     <string name="it_was">Esto fue:</string>
-    <string name="confirm_stats_reset">¿Está seguro de que quiere restaurar sus estadísticas de envío de %1? Esta operación no se puede deshacer.</string>
+    <string name="confirm_stats_reset">¿Está seguro de que quiere limpiar sus estadísticas de envío de %1? Esta operación no se puede deshacer.</string>
     <string name="profile_page">Página del perfil:</string>
     <!-- END status strings -->
     


### PR DESCRIPTION
Some corrections in the Spanish translation, following official Last.fm terminology as seen in www.last.fm/es including: using lower case for "scrobble" and any other word that is not a proper noun or the first word of a sentence, using "tema" as a translation of 'song' and replacing some idioms with more neutral ones. 