### PR TITLE
Scrobble to arbitrary GNU-FM server

### DIFF
--- a/app/src/main/java/com/adam/aslfms/EditUserCredentials.java
+++ b/app/src/main/java/com/adam/aslfms/EditUserCredentials.java
@@ -46,6 +46,8 @@ public class EditUserCredentials extends DialogPreference {
 
 	private EditText mUsername;
 	private EditText mPassword;
+	private EditText mNixtapeUrl;
+	private EditText mGnukeboxUrl;
 
 	private AppSettings settings;
 	private NetApp mNetApp;
@@ -87,6 +89,14 @@ public class EditUserCredentials extends DialogPreference {
 		mUsername.setText(settings.getUsername(mNetApp));
 		mPassword.setText(settings.getPassword(mNetApp));
 
+		if (mNetApp == NetApp.CUSTOM) {
+			mNixtapeUrl = (EditText) view.findViewById(R.id.nixtapeUrl);
+			mGnukeboxUrl = (EditText) view.findViewById(R.id.gnukeboxUrl);
+			mNixtapeUrl.setText(settings.getNixtapeUrl(mNetApp));
+			mGnukeboxUrl.setText(settings.getGnukeboxUrl(mNetApp));
+
+			view.findViewById(R.id.customSettings).setVisibility(View.VISIBLE);
+		}
 	}
 
 	@Override
@@ -109,6 +119,12 @@ public class EditUserCredentials extends DialogPreference {
 			settings.setPassword(mNetApp, password);
 			settings.setPwdMd5(mNetApp, MD5.getHashString(password));
 
+			if (mNetApp == NetApp.CUSTOM) {
+				String nixtapeUrl = mNixtapeUrl.getText().toString().trim();
+				settings.setNixtapeUrl(mNetApp, nixtapeUrl);
+				String gnukeboxUrl = mGnukeboxUrl.getText().toString().trim();
+				settings.setGnukeboxUrl(mNetApp, gnukeboxUrl);
+			}
 			getContext().startService(service);
 		}
 	}

--- a/app/src/main/java/com/adam/aslfms/UserCredActivity.java
+++ b/app/src/main/java/com/adam/aslfms/UserCredActivity.java
@@ -114,7 +114,7 @@ public class UserCredActivity extends AppCompatPreferenceActivity {
 			return true;
 		} else if (pref == mCreateUser) {
 			Intent browser = new Intent(Intent.ACTION_VIEW, Uri.parse(mNetApp
-					.getSignUpUrl()));
+					.getSignUpUrl(settings)));
 			startActivity(browser);
 			return true;
 		}

--- a/app/src/main/java/com/adam/aslfms/service/Handshaker.java
+++ b/app/src/main/java/com/adam/aslfms/service/Handshaker.java
@@ -276,7 +276,7 @@ public class Handshaker extends NetRunnable {
 
             String authToken = MD5.getHashString(pwdMd5 + time);
 
-            String uri = netApp.getHandshakeUrl() + "&p=1.2.1&c=" + clientid
+            String uri = netApp.getHandshakeUrl(settings) + "&p=1.2.1&c=" + clientid
                     + "&v=" + clientver + "&u=" + enc(username) + "&t=" + time
                     + "&a=" + authToken;
 
@@ -355,13 +355,7 @@ public class Handshaker extends NetRunnable {
             URL url;
             HttpsURLConnection conn = null;
             try {
-                if (netApp == NetApp.LASTFM) {
-                    url = new URL("https://ws.audioscrobbler.com/2.0/");
-                } else if (netApp == NetApp.LIBREFM) {
-                    url = new URL("https://libre.fm/2.0/");
-                } else {    // for custom GNU FM server
-                    url = new URL("");
-                }
+                url = new URL(getNetApp().getWebserviceUrl(settings));
 
                 if (!settings.getSessionKey(netApp).equals("")) {
                     Log.i(TAG, "Handshake succeded!: " + netAppName + ": Already has valid session key.");

--- a/app/src/main/java/com/adam/aslfms/service/Heart.java
+++ b/app/src/main/java/com/adam/aslfms/service/Heart.java
@@ -114,12 +114,7 @@ public class Heart extends NetRunnable {
         HttpURLConnection conn = null;
 
         try {
-
-            if (getNetApp() == NetApp.LASTFM) {
-                url = new URL("https://ws.audioscrobbler.com/2.0/");
-            } else {
-                url = new URL("https://libre.fm/2.0/");
-            }
+            url = new URL(getNetApp().getWebserviceUrl(settings));
             conn = (HttpURLConnection) url.openConnection();
 
 

--- a/app/src/main/java/com/adam/aslfms/service/NetApp.java
+++ b/app/src/main/java/com/adam/aslfms/service/NetApp.java
@@ -31,7 +31,7 @@ public enum NetApp {
             "https://ws.audioscrobbler.com/2.0/"), //
     LIBREFM(
             0x02, "Libre.fm", "http://turtle.libre.fm/?hs=true", "librefm",
-            "https://libre.fm/", "https://libre.fm/user/%1", "https://libre.fm/2.0"),
+            "https://libre.fm/", "https://libre.fm/user/%1", "https://libre.fm/2.0/"),
     CUSTOM(
             0x03, "Gnu-fm server", "[[GNUKEBOX_URL]]/?hs=true", "custom",
             "[[NIXTAPE_URL]]", "[[NIXTAPE_URL]]/user/%1", "[[NIXTAPE_URL]]/2.0/");

--- a/app/src/main/java/com/adam/aslfms/service/NetApp.java
+++ b/app/src/main/java/com/adam/aslfms/service/NetApp.java
@@ -27,10 +27,14 @@ import com.adam.aslfms.util.AppSettings;
 public enum NetApp {
     LASTFM(
             0x01, "Last.fm", "http://post.audioscrobbler.com/?hs=true", "",
-            "https://www.last.fm/join", "https://www.last.fm/user/%1"), //
+            "https://www.last.fm/join", "https://www.last.fm/user/%1",
+            "https://ws.audioscrobbler.com/2.0/"), //
     LIBREFM(
             0x02, "Libre.fm", "http://turtle.libre.fm/?hs=true", "librefm",
-            "https://libre.fm/", "https://libre.fm/user/%1");
+            "https://libre.fm/", "https://libre.fm/user/%1", "https://libre.fm/2.0"),
+    CUSTOM(
+            0x03, "Gnu-fm server", "[[GNUKEBOX_URL]]/?hs=true", "custom",
+            "[[NIXTAPE_URL]]", "[[NIXTAPE_URL]]/user/%1", "[[NIXTAPE_URL]]/2.0/");
 
     private final int val;
     private final String name;
@@ -38,15 +42,17 @@ public enum NetApp {
     private final String settingsPrefix;
     private final String signUpUrl;
     private final String profileUrl;
+    private final String webserviceUrl;
 
     NetApp(int val, String name, String handshakeUrl,
-           String settingsPrefix, String signUpUrl, String profileUrl) {
+           String settingsPrefix, String signUpUrl, String profileUrl, String webserviceUrl) {
         this.val = val;
         this.name = name;
         this.handshakeUrl = handshakeUrl;
         this.settingsPrefix = settingsPrefix;
         this.signUpUrl = signUpUrl;
         this.profileUrl = profileUrl;
+        this.webserviceUrl = webserviceUrl;
     }
 
     public String getIntentExtraValue() {
@@ -61,8 +67,8 @@ public enum NetApp {
         return this.name;
     }
 
-    public String getHandshakeUrl() {
-        return this.handshakeUrl;
+    public String getHandshakeUrl(AppSettings settings) {
+        return replacePlaceholders( settings, this.handshakeUrl );
     }
 
     public String getSettingsPrefix() {
@@ -70,11 +76,19 @@ public enum NetApp {
     }
 
     public String getProfileUrl(AppSettings settings) {
-        return profileUrl.replaceAll("%1", settings.getUsername(this));
+        return replacePlaceholders(
+                settings, profileUrl.replaceAll("%1", settings.getUsername(this))
+        );
     }
 
-    public String getSignUpUrl() {
-        return signUpUrl;
+    public String getSignUpUrl(AppSettings settings) {
+        return replacePlaceholders(
+                settings, signUpUrl
+        );
+    }
+
+    public String getWebserviceUrl(AppSettings settings) {
+        return replacePlaceholders(settings, webserviceUrl);
     }
 
     private static SparseArray<NetApp> mValNetAppMap;
@@ -96,4 +110,11 @@ public enum NetApp {
         return napp;
     }
 
+    private String replacePlaceholders(AppSettings settings, String value) {
+        if (settingsPrefix.equals("custom")) {
+            value = value.replace("[[GNUKEBOX_URL]]", settings.getGnukeboxUrl(this));
+            value = value.replace("[[NIXTAPE_URL]]", settings.getNixtapeUrl(this));
+        }
+        return value;
+    }
 }

--- a/app/src/main/java/com/adam/aslfms/service/Scrobbler.java
+++ b/app/src/main/java/com/adam/aslfms/service/Scrobbler.java
@@ -288,13 +288,7 @@ public class Scrobbler extends AbstractSubmitter {
             NetworkerManager mNetManager = new NetworkerManager(mCtx, mDb);
 
             try {
-                if (netApp == NetApp.LASTFM) {
-                    url = new URL("https://ws.audioscrobbler.com/2.0/");
-                } else if (netApp == NetApp.LIBREFM) {
-                    url = new URL("https://libre.fm/2.0/");
-                } else {    // for custom GNU FM server
-                    url = new URL("");
-                }
+                url = new URL(getNetApp().getWebserviceUrl(settings));
 
                 Map<String, Object> params = new TreeMap<>();
                 String sign = "";

--- a/app/src/main/java/com/adam/aslfms/service/UserInfo.java
+++ b/app/src/main/java/com/adam/aslfms/service/UserInfo.java
@@ -101,10 +101,8 @@ public class UserInfo extends NetRunnable {
         try {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB && getNetApp() == NetApp.LIBREFM) {
                 url = new URL("http://libre.fm/2.0/");
-            } else if (getNetApp() == NetApp.LASTFM) {
-                url = new URL("https://ws.audioscrobbler.com/2.0/");
             } else {
-                url = new URL("https://libre.fm/2.0/");
+                url = new URL(getNetApp().getWebserviceUrl(settings));
             }
             conn = (HttpURLConnection) url.openConnection();
 

--- a/app/src/main/java/com/adam/aslfms/util/AppSettings.java
+++ b/app/src/main/java/com/adam/aslfms/util/AppSettings.java
@@ -55,6 +55,8 @@ public class AppSettings {
 
     private static final String KEY_USERNAME = "username";
     private static final String KEY_PASSWORD = "password";
+    private static final String KEY_NIXTAPE_URL = "nixtape_url";
+    private static final String KEY_GNUKEBOX_URL = "gnukebox_url";
     private static final String KEY_PWDMD5 = "pwdMd5";
     private static final String KEY_SESSION = "sessionKey";
     private static final String KEY_SCROBBLES = "totalScrobbles";
@@ -119,6 +121,26 @@ public class AppSettings {
 
     public String getUsername(NetApp napp) {
         return prefs.getString(napp.getSettingsPrefix() + KEY_USERNAME, "");
+    }
+
+    public String getNixtapeUrl(NetApp napp) {
+        return prefs.getString(napp.getSettingsPrefix() + KEY_NIXTAPE_URL, "");
+    }
+
+    public void setNixtapeUrl(NetApp napp, String s) {
+        Editor e = prefs.edit();
+        e.putString(napp.getSettingsPrefix() + KEY_NIXTAPE_URL, s);
+        e.commit();
+    }
+
+    public String getGnukeboxUrl(NetApp napp) {
+        return prefs.getString(napp.getSettingsPrefix() + KEY_GNUKEBOX_URL, "");
+    }
+
+    public void setGnukeboxUrl(NetApp napp, String s) {
+        Editor e = prefs.edit();
+        e.putString(napp.getSettingsPrefix() + KEY_GNUKEBOX_URL, s);
+        e.commit();
     }
 
     /**

--- a/app/src/main/res/layout/edit_user_credentials.xml
+++ b/app/src/main/res/layout/edit_user_credentials.xml
@@ -41,5 +41,43 @@
 			android:layout_marginLeft="10dip"
 			android:layout_marginRight="10dip"
 			android:inputType="textPassword"/>
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:gravity="center_horizontal"
+			android:orientation="vertical"
+			android:id="@+id/customSettings"
+			android:visibility="gone">
+			<TextView
+				android:layout_width="fill_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/nixtapeUrl"
+				android:paddingTop="10dip"
+				android:paddingLeft="10dip"
+				android:paddingRight="10dip" />
+			<EditText
+				android:id="@+id/nixtapeUrl"
+				android:inputType="textUri"
+				android:layout_width="fill_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginLeft="10dip"
+				android:layout_marginRight="10dip"
+				android:singleLine="true" />
+			<TextView
+				android:layout_width="fill_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/gnukeboxUrl"
+				android:paddingTop="10dip"
+				android:paddingLeft="10dip"
+				android:paddingRight="10dip" />
+			<EditText
+				android:id="@+id/gnukeboxUrl"
+				android:inputType="textUri"
+				android:layout_width="fill_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginLeft="10dip"
+				android:layout_marginRight="10dip"
+				android:singleLine="true" />
+		</LinearLayout>
 	</LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,8 @@
     <string name="it_was">It was:</string>
     <string name="confirm_stats_reset">Are you sure you want to reset your submission statistics for %1? This operation cannot be undone.</string>
     <string name="profile_page">Profile page</string>
+    <string name="nixtapeUrl">Nixtape URL</string>
+    <string name="gnukeboxUrl">Gnukebox URL</string>
     <!-- END status strings -->
 
 </resources>


### PR DESCRIPTION
Not ideal, but it seems to work. Adds a 'CUSTOM' netapp type that
gets a couple extra settings - urls for the nixtape and gnukebox
installs.

Simple implementation of #18, also DRYs up some repeated URL logic