### PR TITLE
Android automatic refactor - ViewHolder

### DIFF
--- a/app/src/main/java/com/adam/aslfms/StatusFragment.java
+++ b/app/src/main/java/com/adam/aslfms/StatusFragment.java
@@ -294,17 +294,31 @@ public class StatusFragment extends Fragment {
             super(context, resource, textViewResourceId, list);
         }
 
-        @Override
+        private static class ViewHolderItem {
+			private TextView keyView;
+			private TextView valueView;
+		}
+
+		@Override
         public View getView(int position, View convertView, ViewGroup parent) {
-            View view = LayoutInflater.from(getContext()).inflate(
-                    R.layout.status_info_row, parent, false);
+            ViewHolderItem viewHolderItem;
+			if (convertView == null) {
+				convertView = LayoutInflater.from(getContext()).inflate(
+				        R.layout.status_info_row, parent, false);
+				viewHolderItem = new ViewHolderItem();
+				viewHolderItem.keyView = (TextView) convertView.findViewById(R.id.key);
+				viewHolderItem.valueView = (TextView) convertView.findViewById(R.id.value);
+				convertView.setTag(viewHolderItem);
+			} else {
+				viewHolderItem = (ViewHolderItem) convertView.getTag();
+			}
+			View view = convertView;
+			Pair item = this.getItem(position);
 
-            Pair item = this.getItem(position);
-
-            TextView keyView = (TextView) view.findViewById(R.id.key);
+            TextView keyView = viewHolderItem.keyView;
             keyView.setText(item.getKey());
 
-            TextView valueView = (TextView) view.findViewById(R.id.value);
+            TextView valueView = viewHolderItem.valueView;
             valueView.setText(item.getValue());
 
             return view;


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ViewHolder".

When developing list views, it is very common to repeat work in every item. Something very common is retrieving a field with the API method ```findViewById```. There is a ViewHolder pattern that lets you reuse the work made in the previous computed item.

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis
