### PR TITLE
Update a few *Brainz related things

### DIFF
--- a/Developer's API.md
+++ b/Developer's API.md
@@ -35,7 +35,7 @@ The possible fields for the intent (to be put in its extras bundle) are:
     | track        | String | Yes      | The track name                                                      |
     | duration     | int    | Yes      | The duration of the track (in seconds)                              |
     | track-number | int    | No       | Track number on album                                               |
-    | mbid         | String | No       | A Track-ID from <http://musicbrainz.org/doc/TrackID>                |
+    | mbid         | String | No       | A MusicBrainz Recording ID <https://musicbrainz.org/doc/MBID>       |
     | source       | String | No       | How the user listens to the music, see table below (default is 'P') |
 
 Table of source values:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Simple Last.fm Scrobbler (and Libre.fm and Listen Brainz and Custom Personal Servers)
+# Simple Last.fm Scrobbler (and Libre.fm and ListenBrainz and Custom Personal Servers)
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tgwizard/sls)
 [![License](http://img.shields.io/:license-apache-blue.svg?style=round)](LICENSE.md)
 [![Google+](http://ibin.co/2BnMUC5fKA2e)](https://plus.google.com/communities/104841597680405981934)
 
-Simple Last.fm Scrobbler (SLS) is a simple app that scrobbles music listened to on an Android phone. Scrobbling means submitting listening information to Last.fm (and optionally/additionally Libre.fm and Listen Brainz) when you play a track, and you can then get music recommendations and view you listening history and statistics at Last.fm.
+Simple Last.fm Scrobbler (SLS) is a simple app that scrobbles music listened to on an Android phone. Scrobbling means submitting listening information to Last.fm (and optionally/additionally Libre.fm and ListenBrainz) when you play a track, and you can then get music recommendations and view you listening history and statistics at Last.fm.
 
 Before the release of a new version of SLS, it will be available here to test for one week in the [Beta Testing Versions link](README.md#download).
 
@@ -59,9 +59,9 @@ Head to [Transifex](https://www.transifex.com/sls/sls) if you want to be a trans
 
  * [Last.fm](http://last.fm)
  * [Libre.fm](http:///libre.fm)
- * [Listen Brainz](https://listenbrainz.org)
+ * [ListenBrainz](https://listenbrainz.org)
  * [Custom GNU-fm/Libre.fm Server](https://git.gnu.io/gnu/gnu-fm/blob/master/gnufm_install.txt)
- * [Custom Listen Brainz Server](https://github.com/metabrainz/listenbrainz-server/blob/master/README.md)
+ * [Custom ListenBrainz Server](https://github.com/metabrainz/listenbrainz-server/blob/master/README.md)
 
 ### Apps
 

--- a/app/src/androidTest/java/com/adam/aslfms/util/TrackTestUtils.java
+++ b/app/src/androidTest/java/com/adam/aslfms/util/TrackTestUtils.java
@@ -31,8 +31,7 @@ public class TrackTestUtils {
     public static final String TEST_TRACK = "The World";
     public static final int TEST_DURATION = 123;
     public static final String TEST_TRACK_NR = "13";
-    // TODO: make it look like a real mbid
-    public static final String TEST_MBID = "asdf8o32479213924";
+    public static final String TEST_MBID = "a1aa722e-06e4-4464-a585-c93471ecb449";
     public static final String TEST_SOURCE = "R";
     public static final String TEST_RATING = "";
     public static final long TEST_WHEN = 12394649;

--- a/app/src/main/assets/changelog.txt
+++ b/app/src/main/assets/changelog.txt
@@ -4,7 +4,7 @@
   * Add Chinese translation (thanks to cmpute)
 
 - 1.5.3 (2016-11-21)
-  * Listen Brainz support (testing)
+  * ListenBrainz support (testing)
   * Clear Unused Apps List Feature
   * Only Show Logged In Services in Status
   * Apache 2.0 License

--- a/app/src/main/java/com/adam/aslfms/service/NetApp.java
+++ b/app/src/main/java/com/adam/aslfms/service/NetApp.java
@@ -33,7 +33,7 @@ public enum NetApp {
             0x02, "Libre fm", "http://turtle.libre.fm/?hs=true", "librefm",
             "https://libre.fm/", "https://libre.fm/user/%1", "https://libre.fm/2.0/"),
     LISTENBRAINZ(
-            0x03, "Listen Brainz", "LISTENBRAINZ_URL", "listenbrainz",
+            0x03, "ListenBrainz", "LISTENBRAINZ_URL", "listenbrainz",
             "https://listenbrainz.org/login/", "https://listenbrainz.org/user/%1", "https://api.listenbrainz.org/1/"),
     CUSTOM(
             0x04, "GNU-fm server", "[[GNUKEBOX_URL]]/?hs=true", "custom",

--- a/app/src/main/res/values/strings_nontranslatable.xml
+++ b/app/src/main/res/values/strings_nontranslatable.xml
@@ -9,9 +9,9 @@
     <string name="clear_apps" translatable="false">Clear Apps</string> <!-- TODO: Translate -->
     <string name="nixtapeUrl" translatable="false">Nixtape URL</string>
     <string name="gnukeboxUrl" translatable="false">Gnukebox URL</string>
-    <string name="listenBrainzURL" translatable="false">Listen Brainz URL</string>
-    <string name="listenBrainzApiURL" translatable="false">Listen Brainz API URL</string>
-    <string name="listenBrainzToken" translatable="false">Listen Brainz Token</string>
+    <string name="listenBrainzURL" translatable="false">ListenBrainz URL</string>
+    <string name="listenBrainzApiURL" translatable="false">ListenBrainz API URL</string>
+    <string name="listenBrainzToken" translatable="false">ListenBrainz Token</string>
     <string name="supported_musicapps" translatable="false">Spotify, Google Music, Deezer, 
 		Rhapsody/Napster, Rdio, My Cloud Player, SoundCloud, 8tracks, 
 		InfiniTracks, Squeezer, Amazon Music, Huawei, n7player, BuMP, PowerAMP, Black Player, AIMP, 


### PR DESCRIPTION
1. Make the `TEST_MBID` an actual MBID instead of a "random" string.
2. Make it clear that the Last.FM `mbid` refers to a MusicBrainz [Recording](https://musicbrainz.org/doc/Recording) entity, not a [Track](https://musicbrainz.org/doc/Track).
3. Replace "Listen Brainz" with "ListenBrainz".

See individual commit messages for more information about each commit.