### PR TITLE
Listenbrainz fixes

### DIFF
--- a/app/src/main/java/com/adam/aslfms/service/NPNotifier.java
+++ b/app/src/main/java/com/adam/aslfms/service/NPNotifier.java
@@ -210,8 +210,7 @@ public class NPNotifier extends AbstractSubmitter {
                 JSONObject baseObj = new JSONObject();
                 baseObj.put("listen_type", "playing_now");
                 JSONObject trackInfo = new JSONObject();
-                trackInfo.put("listened_at", Long.toString(track.getWhen()));
-
+                
                 JSONObject trackMetaData = new JSONObject();
                 trackMetaData.put("artist_name", track.getArtist());
                 trackMetaData.put("track_name", track.getTrack());

--- a/app/src/main/java/com/adam/aslfms/service/NPNotifier.java
+++ b/app/src/main/java/com/adam/aslfms/service/NPNotifier.java
@@ -266,7 +266,7 @@ public class NPNotifier extends AbstractSubmitter {
                 if (response.equals("")) {
                     throw new AuthStatus.UnknownResponseException("Empty response");
                 }
-                if (response.startsWith("success")) {
+                if (resCode == 200 && response.indexOf("ok") > -1) {
                     Log.i(TAG, "Now Playing success: " + netAppName);
                 } else {
                     throw new AuthStatus.UnknownResponseException("Invalid Response");

--- a/app/src/main/java/com/adam/aslfms/service/NPNotifier.java
+++ b/app/src/main/java/com/adam/aslfms/service/NPNotifier.java
@@ -261,7 +261,7 @@ public class NPNotifier extends AbstractSubmitter {
                 Log.d(TAG, response);
                 if (resCode == 401) {
                     settings.setListenBrainzToken(netApp, "");
-                    throw new BadSessionException("Now Playing failed because of badsession");
+                    throw new BadSessionException("Now Playing failed because of bad token.");
                 }
                 if (response.equals("")) {
                     throw new AuthStatus.UnknownResponseException("Empty response");

--- a/app/src/main/java/com/adam/aslfms/service/Scrobbler.java
+++ b/app/src/main/java/com/adam/aslfms/service/Scrobbler.java
@@ -304,16 +304,21 @@ public class Scrobbler extends AbstractSubmitter {
                 Log.d(TAG, response);
                 if (resCode == 401) {
                     settings.setListenBrainzToken(netApp, "");
-                    throw new BadSessionException("Now Playing failed because of badsession");
+                    throw new BadSessionException("Listenbrainz submission failed because of bad token.");
                 }
                 if (response.equals("")) {
                     throw new AuthStatus.UnknownResponseException("Empty response");
                 }
-                if (resCode == 200 && response.indexOf("ok") > -1) {
-                    Log.i(TAG, "Scrobble success: " + netAppName);
-                    /*if (settings.isNowPlayingEnabled(pow)) { // support is coming
-                        mNetManager.launchGetUserInfo(getNetApp());
-                    }*/
+                JSONObject jObject = new JSONObject(response);
+                if (jObject.has("status")) {
+                    Log.i(TAG, "Listen success: " + netAppName);
+                } else if (jObject.has("error")) {
+                    Log.i(TAG, "Listen failed: " + response);
+                    if (resCode != 400) {
+                        // don't throw if code is 400 because it's a badly formatted
+                        // submission and we don't want to cache/try again
+                        throw new AuthStatus.UnknownResponseException("Invalid Response");
+                    }
                 } else {
                     throw new AuthStatus.UnknownResponseException("Invalid Response");
                 }

--- a/app/src/main/java/com/adam/aslfms/service/Scrobbler.java
+++ b/app/src/main/java/com/adam/aslfms/service/Scrobbler.java
@@ -309,7 +309,7 @@ public class Scrobbler extends AbstractSubmitter {
                 if (response.equals("")) {
                     throw new AuthStatus.UnknownResponseException("Empty response");
                 }
-                if (response.startsWith("success")) {
+                if (resCode == 200 && response.indexOf("ok") > -1) {
                     Log.i(TAG, "Scrobble success: " + netAppName);
                     /*if (settings.isNowPlayingEnabled(pow)) { // support is coming
                         mNetManager.launchGetUserInfo(getNetApp());


### PR DESCRIPTION
Since the LB server went in to beta, the app doesn't recognise the updated response from a successful listen and continuously caches/retries when there is no need. Should fix #385 

Also, don't send "listened_at" with "playing_now" requests as this causes the server to return a 400 bad request error. This isn't documented and I've mentioned it over on the LB issues system...

https://tickets.metabrainz.org/projects/LB/issues/LB-206