### PR TITLE
Fix scrobbling on Android 8 and higher

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.0'
+    compileSdkVersion 25
     defaultConfig {
         applicationId "com.adam.aslfms"
-        minSdkVersion 14
-        targetSdkVersion 26
+        minSdkVersion 9
+        targetSdkVersion 25
 
         testApplicationId "com.adam.aslfms.test"
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
@@ -21,8 +20,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:26.0.0'
-    compile 'com.android.support:support-v4:26.0.0'
-    compile 'com.android.support:design:26.0.0'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.android.support:design:25.4.0'
     //compile 'info.guardianproject.netcipher:netcipher:1.2'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.adam.aslfms"
-    android:versionCode="46"
-    android:versionName="1.5.5">
+    android:versionCode="48"
+    android:versionName="1.5.7">
 
     <supports-screens
         android:anyDensity="true"

--- a/app/src/main/assets/changelog.txt
+++ b/app/src/main/assets/changelog.txt
@@ -1,5 +1,10 @@
+- 1.5.7 (2018-1-8)
+  * Fix scrobbles on Android 8 and higher (thanks to G00fY2)
+  * Switch to SDK 25 to allow receiving implicit broadcasts
+  * Add back Android 2.3 Support
+
 - 1.5.6 (2017-9-17)
-  *
+  * Update from Android 24 SDK to 26 (Android 8)
 
 - 1.5.5 (2017-9-16)
   * ListenBrainz fix (thanks to @19379)

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,9 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
     }
 }


### PR DESCRIPTION
Updating to sls 1.5.6 broke scrobbling on my Pixel running Android 8.1 stable.

In logcat I found the following message:
```
BroadcastQueue: Background execution not allowed: receiving Intent { act=com.spotify.music.playbackstatechanged flg=0x10 (has extras) } to com.adam.aslfms/.receiver.SpotifyReceiver
```

This is due to [changes in Androids background execution limits](https://developer.android.com/about/versions/oreo/android-8.0-changes.html#back-all), which  affects all apps targeting sdk 26 and higher.

> Apps cannot use their manifests to register for most implicit broadcasts (that is, broadcasts that are not targeted specifically at the app).


Here are some details and information how to deal with the changes: **[Android O and the Implicit Broadcast Ban](https://commonsware.com/blog/2017/04/11/android-o-implicit-broadcast-ban.html)**

So atm the only way I see is to stuck with targetSDK 25.

The problem: Starting with [November 2018 it won't be possible to release updates targeting SKD <26](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html). So if we want to be able to release updates on Google Play Store we properly need to rewrite the receiver logic (if there will be any way to fetch the media intents on Android 8+ at all).

Beside switching to SDK 25 I took the liberty to update the changelog and give myself credits.:sweat_smile: I hope you're okay with that.
  
Fixes #414