### PR TITLE
Replace snackbar with toasts for better visiblity

### DIFF
--- a/app/src/main/java/com/adam/aslfms/SettingsActivity.java
+++ b/app/src/main/java/com/adam/aslfms/SettingsActivity.java
@@ -120,7 +120,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        credsCheck();
         unregisterReceiver(onStatusChange);
     }
 
@@ -129,6 +128,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         super.onResume();
 
         checkNetwork();
+        credsCheck();
 
         IntentFilter ifs = new IntentFilter();
         ifs.addAction(ScrobblingService.BROADCAST_ONSTATUSCHANGED);
@@ -203,7 +203,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     private void checkNetwork() {
         this.sendBroadcast(new Intent(AppSettings.ACTION_NETWORK_OPTIONS_CHANGED));
         if (Util.checkForOkNetwork(this) != Util.NetworkStatus.OK) {
-            Snackbar.make(getListView(), getString(R.string.limited_network), Snackbar.LENGTH_SHORT).show();
+            Toast.makeText(this, getString(R.string.limited_network), Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -214,7 +214,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 return;
             }
         }
-        Snackbar.make(getListView(), this.getString(R.string.creds_required), Snackbar.LENGTH_LONG).show();
+        Toast.makeText(this, this.getString(R.string.creds_required), Toast.LENGTH_LONG).show();
     }
 
     private void permsCheck() {


### PR DESCRIPTION
The dark snackbar is barely visible and doesn't get the users attention. I have not noticed it at all at first start.

I think the best way to go is to use traditional Toasts.

Also the credentials check which shows the snackbar was called in onPause, which doesn't make any sense to me. It should be called in the onResume, just like the network check.

I attached some comparison screenshots two with Android 8.1 and two with Android 5.1 for you to see what I mean.

![screenshot_20180108-232302](https://user-images.githubusercontent.com/1990806/34695676-f9fdc520-f4cb-11e7-88cc-6cf732d351a3.png)
![screenshot_20180108-232216](https://user-images.githubusercontent.com/1990806/34695681-fb40d83c-f4cb-11e7-8dde-9bfa5b9cadeb.png)
![screenshot_2018-01-08-23-38-22](https://user-images.githubusercontent.com/1990806/34695984-3d18165c-f4cd-11e7-9e28-488cd4a5fbc6.png)
![screenshot_2018-01-08-23-38-45](https://user-images.githubusercontent.com/1990806/34695985-40714dfa-f4cd-11e7-8b27-2937dfabcc0f.png)


  