### PR TITLE
Fix credsCheck in onPause

### DIFF
--- a/app/src/main/java/com/adam/aslfms/SettingsActivity.java
+++ b/app/src/main/java/com/adam/aslfms/SettingsActivity.java
@@ -120,7 +120,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        credsCheck();
         unregisterReceiver(onStatusChange);
     }
 
@@ -129,6 +128,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         super.onResume();
 
         checkNetwork();
+        credsCheck();
 
         IntentFilter ifs = new IntentFilter();
         ifs.addAction(ScrobblingService.BROADCAST_ONSTATUSCHANGED);


### PR DESCRIPTION
Checking the credentials to show an error in the snackbar makes no sense in onPause. This belongs in onResume.